### PR TITLE
Updated AddKeywordTo functions to fix not working on first call bug

### DIFF
--- a/po3_papyrusextender/po3_functions.cpp
+++ b/po3_papyrusextender/po3_functions.cpp
@@ -1435,6 +1435,14 @@ void PO3_SKSEFunctions::AddKeywordToForm(TESForm* thisForm, BGSKeyword* KYWDtoAd
 			free(oldData);
 			oldData = nullptr;
 		}
+		else {
+			//There is no old keyword array just add to the new keyword array
+			pKeywords->keywords[0] = KYWDtoAdd;
+
+			//Better safe than sorry
+			free(oldData);
+			oldData = nullptr;
+		}
 	}
 }
 
@@ -2407,6 +2415,14 @@ void PO3_SKSEFunctions::AddKeywordToRef(TESObjectREFR* thisRef, BGSKeyword* KYWD
 
 			pKeywords->keywords[pKeywords->numKeywords - 1] = KYWDtoAdd;
 
+			free(oldData);
+			oldData = nullptr;
+		}
+		else {
+			//There is no old keyword array just add to the new keyword array
+			pKeywords->keywords[0] = KYWDtoAdd;
+
+			//Better safe than sorry
 			free(oldData);
 			oldData = nullptr;
 		}


### PR DESCRIPTION
The AddKeywordTo functions did not handle the case of a form/ref with no keyword list. This caused the first papyrus call on keywordless forms/refs to not add the keyword. The logic did allow for subsequent calls of the function to work so no change was needed in the original logic.